### PR TITLE
create a default ruleset in scirius

### DIFF
--- a/Suricata/vagrant/singlehost/Vagrantfile
+++ b/Suricata/vagrant/singlehost/Vagrantfile
@@ -144,6 +144,13 @@ ln -s /etc/nginx/sites-available/stamus.conf /etc/nginx/sites-enabled/stamus.con
 chown www-data /var/log/scirius*
 chown www-data /tmp/scirius_error_logs.log
 
+source /usr/share/python/scirius/bin/activate
+python /usr/share/python/scirius/bin/manage.py addsource "ETOpen Ruleset" https://rules.emergingthreats.net/open/suricata-3.0/emerging.rules.tar.gz http sigs
+python /usr/share/python/scirius/bin/manage.py addsource "PT Research Ruleset" https://github.com/ptresearch/AttackDetection/raw/master/pt.rules.tar.gz http sigs
+python /usr/share/python/scirius/bin/manage.py defaultruleset "CDMCS ruleset"
+python /usr/share/python/scirius/bin/manage.py addsuricata suricata "Suricata on CDMCS" /etc/suricata/rules "CDMCS ruleset"
+python /usr/share/python/scirius/bin/manage.py updatesuricata
+deactivate
 
 
 systemctl enable supervisor.service


### PR DESCRIPTION
This is a workaround to an issue in scirius that prevent the user
from starting from scratch without seeing an error during the
test phase of the source.