### PR TITLE
RFE: Suricata PID readable to others

### DIFF
--- a/Suricata/vagrant/singlehost/Vagrantfile
+++ b/Suricata/vagrant/singlehost/Vagrantfile
@@ -81,9 +81,11 @@ EOF
 touch  /etc/suricata//threshold.config
 #suricata -T -vvv
 [[ $(suricata -T) ]] || exit -1
+#Fixed some weird systemd/init.d daemon pid file creating behavior. PID file in /var/run/ should be readable by all. 
+sed -i -e 's/$DAEMON $SURICATA_OPTIONS > \\/var\\/log\\/suricata\\/suricata-start.log  2>\\&1 \\&/$DAEMON $SURICATA_OPTIONS > \\/var\\/log\\/suricata\\/suricata-start.log 2>\\&1\\n       chmod 644 $PIDFILE > \\/dev\\/null 2>\\&1 || true/' /etc/init.d/suricata
+systemctl daemon-reload
 systemctl enable suricata > /dev/null 2>&1
 systemctl start suricata
-chown root:adm /var/run/*.pid
 cat >> /etc/telegraf/telegraf.conf <<EOF
 [[inputs.procstat]]
     pid_file = "/var/run/suricata.pid"


### PR DESCRIPTION
Due to some kind of bug I added chmod 644 command to /etc/init.d/suricata script to other process be able to read PID number from /var/run/suricata.pid file. I also removed & from end of suricata startup line because sometimes changing permissions operation was executed before suricata was able to create a pid file.